### PR TITLE
Add shell.nix and .gitignore, flag for building tester, clean up codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*~
+.#*
+.*.swp
+*.hi
+*.o
+*.hepmc
+.cabal-sandbox
+cabal.sandbox.config
+dist
+TAGS

--- a/HepMC.cabal
+++ b/HepMC.cabal
@@ -11,39 +11,44 @@ category:            Physics
 build-type:          Simple
 cabal-version:       >=1.8
 
-executable tester
-   main-is:             tester.hs
-   hs-source-dirs:      exe
-   ghc-options: 	-Wall -threaded -funbox-strict-fields -fno-warn-unused-do-bind
-   ghc-prof-options: -caf-all -auto-all
-   build-depends:   base == 4.*,
-                    -- 
-                    attoparsec,
-                    pipes,
-                    pipes-attoparsec,
-                    pipes-parse,
-                    pipes-text,
-                    text,
-                    transformers,
-                    --
-                    HepMC
+flag devel
+  description:       Create small test executables
+  default:           False
 
+executable tester
+   main-is:          tester.hs
+   hs-source-dirs:   exe
+   ghc-options:      -Wall -threaded -funbox-strict-fields -fno-warn-unused-do-bind
+   ghc-prof-options: -caf-all -auto-all
+   build-depends:    base == 4.*,
+                     --
+                     attoparsec,
+                     pipes,
+                     pipes-attoparsec,
+                     pipes-parse,
+                     pipes-text,
+                     text,
+                     transformers,
+                     --
+                     HepMC
+  if flag(devel)
+    buildable:       True
+  else
+    buildable:       False
 
 Library
-  hs-source-dirs: src
-  ghc-options: 	-Wall -funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans
-  ghc-prof-options: -caf-all -auto-all
-  Build-Depends:   base == 4.*,
-                   -- 
-                   attoparsec,
-                   bytestring,
-                   blaze-builder,
-                   pipes-attoparsec,
-                   text
-  Exposed-Modules: 
-                   HEP.Parser.HepMC.Builder
-                   HEP.Parser.HepMC.Parser
-                   HEP.Parser.HepMC.Type
-
-  Other-Modules: 
-
+  hs-source-dirs:    src
+  ghc-options:       -Wall -funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans
+  ghc-prof-options:  -caf-all -auto-all
+  Build-Depends:     base == 4.*,
+                     --
+                     attoparsec,
+                     bytestring,
+                     blaze-builder,
+                     pipes-attoparsec,
+                     text
+  Exposed-Modules:
+                     HEP.Parser.HepMC.Builder
+                     HEP.Parser.HepMC.Parser
+                     HEP.Parser.HepMC.Type
+  Other-Modules:

--- a/exe/tester.hs
+++ b/exe/tester.hs
@@ -2,65 +2,61 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.State.Strict
-import qualified Data.Attoparsec.Text as A
-import           Data.Text 
-import qualified Data.Text.IO as TIO
+-- import qualified Data.Attoparsec.Text             as A
+import           Data.Text
+-- import qualified Data.Text.IO                     as TIO
 -- import           Pipes (await, runEffect, yield, (>->))
 import           Pipes
+import qualified Pipes.Attoparsec                 as PA
+import qualified Pipes.Parse                      as PP
 import qualified Pipes.Prelude
-import qualified Pipes.Attoparsec as PA
-import qualified Pipes.Parse as PP
-import qualified Pipes.Text.IO as PIO
+import qualified Pipes.Text.IO                    as PIO
 import           System.Environment
-import           System.IO (withFile, IOMode(..),  stdout)
--- 
+import           System.IO                        (IOMode (..), withFile)
+--
 import           HEP.Parser.HepMC.Parser
 import           HEP.Parser.HepMC.Type
 --
 
 takeWait :: (Monad m) => Int -> Pipe a a m ()
-takeWait n = worker 0 
-  where worker m 
-          | m > n = await >> worker (m+1)  
-          | otherwise = await >>= yield >> worker (m+1)        
+takeWait n = worker 0
+  where worker m
+          | m > n = await >> worker (m+1)
+          | otherwise = await >>= yield >> worker (m+1)
 
-main = do 
-  putStrLn "hepmc tester" 
-  args <- getArgs 
+main :: IO ()
+main = do
+  putStrLn "hepmc tester"
+  args <- getArgs
   let filename = args !! 0
       p = PA.parse hepmcHeader
-  print filename 
-  withFile filename ReadMode $ \hin -> 
+  print filename
+  withFile filename ReadMode $ \hin ->
     runEffect $ do
-      (r1,s) <- lift (runStateT p (PIO.fromHandle hin))
-      action s >-> Pipes.Prelude.tee (counter 100 0 >-> forever (await >> return ())) 
+      (_, s) <- lift (runStateT p (PIO.fromHandle hin))
+      action s >-> Pipes.Prelude.tee (counter 100 0 >-> forever (await >> return ()))
         >-> takeWait 500 >-> counter 70 0 >-> (replicateM 3 printer >> forever (await >> return ())) -- printer
   return ()
 
 evp :: (Monad m) => PP.Parser Text m (Maybe (Either PA.ParsingError GenEvent))
 evp = PA.parse event
 
-action :: (Monad m) => Producer Text m () -> Producer GenEvent m () 
+action :: (Monad m) => Producer Text m () -> Producer GenEvent m ()
 action s = do
   (r,s') <- lift (runStateT evp s)
   case r of
     Nothing -> return ()
-    Just (Left err) -> return ()
+    Just (Left _)   -> return ()
     Just (Right ev) -> yield ev >> action s'
 
- 
-counter :: (MonadIO m, Monad m) => Int -> Int -> Pipe a a m () 
-counter m n = do 
+counter :: (MonadIO m, Monad m) => Int -> Int -> Pipe a a m ()
+counter m n = do
   e <- await
-  if n `mod` m == 0 then liftIO (print n) else return ()  
-  yield e 
+  if n `mod` m == 0 then liftIO (print n) else return ()
+  yield e
   counter m (n+1)
 
-
-printer :: (MonadIO m, Monad m, Show a) => Consumer a m () 
+printer :: (MonadIO m, Monad m, Show a) => Consumer a m ()
 printer = do
-  a <- await 
+  a <- await
   liftIO (print a)
-
-
-

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+with (import <nixpkgs> {}).pkgs;
+let pkg = haskellngPackages.callPackage
+            ({ mkDerivation, attoparsec, base, blaze-builder, bytestring, pipes
+             , pipes-attoparsec, pipes-parse, pipes-text, stdenv, text
+             , transformers
+             }:
+             mkDerivation {
+               pname = "HepMC";
+               version = "0.0";
+               src = ./.;
+               isLibrary = true;
+               isExecutable = true;
+               buildDepends = [
+                 attoparsec base blaze-builder bytestring pipes pipes-attoparsec
+                 pipes-parse pipes-text text transformers
+               ];
+               homepage = "http://github.com/wavewave/HepMC";
+               description = "Haskell HepMC parser and builder";
+               license = stdenv.lib.licenses.gpl3;
+             }) {};
+in
+  pkg.env

--- a/src/HEP/Parser/HepMC/Builder.hs
+++ b/src/HEP/Parser/HepMC/Builder.hs
@@ -1,84 +1,88 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module HEP.Parser.HepMC.Builder where
 
-import Blaze.ByteString.Builder
-import Blaze.ByteString.Builder.Char.Utf8
-import           Control.Category ((>>>))
-import qualified Data.ByteString.Char8 as B
-import qualified Data.Foldable as F
-import Data.Monoid
-import qualified Data.Text as T
+import           Blaze.ByteString.Builder
+import           Blaze.ByteString.Builder.Char.Utf8
+import           Control.Category                   ((>>>))
+-- import qualified Data.ByteString.Char8              as B
+import qualified Data.Foldable                      as F
+import           Data.Monoid                        ((<>))
+-- import qualified Data.Text                          as T
 
-import HEP.Parser.HepMC.Type 
+import           HEP.Parser.HepMC.Type
 
 buildParticle :: GenParticle -> Builder
-buildParticle GenParticle {..} = fromText "P " 
-                                 <> fromShow pbarcode <> space 
+buildParticle GenParticle {..} = fromText "P "
+                                 <> fromShow pbarcode <> space
                                  <> fromShow pidPDG <> space
                                  <> fromShow px <> space
-                                 <> fromShow py <> space 
-                                 <> fromShow pz <> space 
-                                 <> fromShow pE <> space 
+                                 <> fromShow py <> space
+                                 <> fromShow pz <> space
+                                 <> fromShow pE <> space
                                  <> fromShow generatedMass <> space
                                  <> fromShow statusCode <> space
                                  <> fromShow polTheta <> space
                                  <> fromShow polPhi <> space
-                                 <> fromShow vbarcode4ThisIncoming <> space 
-                                 <> (let (n,lst) = flows 
-                                     in fromShow n <> space
+                                 <> fromShow vbarcode4ThisIncoming <> space
+                                 <> (let (n, lst) = flows
+                                     in fromShow n
+                                        <> space
                                         <> mconcat (map (\x -> fromShow x <> space) lst))
 
-buildVertex GenVertex {..} = 
+buildVertex :: GenVertex -> Builder
+buildVertex GenVertex {..} =
     fromText "V "
     <> fromShow vbarcode <> space
-    <> fromShow vid <> space 
-    <> fromShow vx <> space 
+    <> fromShow vid <> space
+    <> fromShow vx <> space
     <> fromShow vy <> space
     <> fromShow vz <> space
-    <> fromShow vctau <> space 
+    <> fromShow vctau <> space
     <> fromShow numOrphanInPtl <> space
     <> fromShow numOutPtl <> space
-    <> (let (n,lst) = vertexWeights
+    <> (let (n, lst) = vertexWeights
         in fromShow n <> space
            <> mconcat (map (\x -> fromShow x <> space) lst))
     <> fromText "\n"
     <> mconcat (map (\x -> buildParticle x <> fromText "\n") particles)
 
-  
 buildHeader :: EventHeader -> Builder
-buildHeader EventHeader {..} = 
+buildHeader EventHeader {..} =
     maybe mempty buildWeightInfo mWeightInfo
     <> maybe mempty (buildUnitInfo >>> (<> fromText "\n")) mUnitInfo
     <> maybe mempty (buildXsecInfo >>> (<> fromText "\n")) mXsecInfo
     <> maybe mempty (buildHeavyIonInfo >>> (<> fromText "\n")) mHeavyIonInfo
     <> maybe mempty (buildPdfInfo >>> (<> fromText "\n"))  mPdfInfo
-  where buildWeightInfo NamedWeight {..} = undefined -- postpone 
+  where buildWeightInfo NamedWeight {..} = undefined -- postpone
         buildUnitInfo MomentumPositionUnit {..} = fromText "U " <> fromText (case momentumUnit of GeV -> "GEV" ; MeV -> "MEV")
-                                                                <> space 
+                                                                <> space
                                                                 <> fromText (case lengthUnit of MM -> "MM" ; CM -> "CM")
         buildXsecInfo GenXSec {..} = fromText "C " <> fromShow xsecInPb <> space <> fromShow errorInXsec
         buildHeavyIonInfo _ = undefined  -- postpone
         buildPdfInfo _ = undefined -- postpone
 
-space = fromText " " 
+space :: Builder
+space = fromText " "
+
+newline :: Builder
 newline = fromText "\n"
 
 buildEvent :: GenEvent -> Builder
-buildEvent GenEvent {..} =  fromText "E " 
+buildEvent GenEvent {..} =  fromText "E "
                            <> fromShow eventNumber <> space
                            <> fromShow numMultiparticleInteractions <> space
-                           <> fromShow eventScale <> space 
+                           <> fromShow eventScale <> space
                            <> fromShow alphaQCD <> space
-                           <> fromShow alphaQED <> space 
+                           <> fromShow alphaQED <> space
                            <> fromShow signalProcessId <> space
                            <> fromShow barcode4SignalProcessVtx <> space
                            <> fromShow numVtx <> space
                            <> fromShow barcodeBeam1 <> space
                            <> fromShow barcodeBeam2 <> space
-                           <> (let (n1,lst1) = randomStateList 
-                               in fromShow n1 <> space <> mconcat (map (fromShow >>> (<> space)) lst1)) 
+                           <> (let (n1,lst1) = randomStateList
+                               in fromShow n1 <> space <> mconcat (map (fromShow >>> (<> space)) lst1))
                            <> (let (n2,lst2) = weightList
                                in fromShow n2 <> space <> mconcat (map (fromShow >>> (<> space)) lst2))
                            <> newline
@@ -86,7 +90,5 @@ buildEvent GenEvent {..} =  fromText "E "
                            <> F.foldMap buildVertex vertices
 
 buildHepMC :: [GenEvent] -> Builder
-buildHepMC evts = fromText "HepMC::Version 2.06.09\nHepMC::IO_GenEvent-START_EVENT_LISTING\n" 
+buildHepMC evts = fromText "HepMC::Version 2.06.09\nHepMC::IO_GenEvent-START_EVENT_LISTING\n"
                   <> F.foldMap buildEvent evts
-
-

--- a/src/HEP/Parser/HepMC/Type.hs
+++ b/src/HEP/Parser/HepMC/Type.hs
@@ -1,107 +1,98 @@
 module HEP.Parser.HepMC.Type where
 
-import Data.Text
+import           Data.Text (Text)
 
 type Version = Text
 
 -- data EventBlock = EventBlock Version [ Event ]
 
-data MomentumUnit = GeV | MeV 
-                  deriving (Show)
+data MomentumUnit = GeV | MeV deriving (Show)
 
-data LengthUnit = MM | CM
-                deriving (Show)
+data LengthUnit = MM | CM deriving (Show)
 
-data GenEvent = GenEvent { eventNumber :: Int
+data GenEvent = GenEvent { eventNumber                  :: Int
                          , numMultiparticleInteractions :: Int
-                         , eventScale :: Double
-                         , alphaQCD :: Double
-                         , alphaQED :: Double
-                         , signalProcessId :: Int
-                         , barcode4SignalProcessVtx :: Int
-                         , numVtx :: Int
-                         , barcodeBeam1 :: Int
-                         , barcodeBeam2 :: Int
-                         , randomStateList :: (Int, [Int]) -- ^ (numEntries, randomStateIntergers)
-                         , weightList :: (Int, [Double])  -- ^ (numEntries, weights )
-                         , eventHeader :: EventHeader
-                         , vertices :: [GenVertex]
-                         }
-              deriving (Show) 
+                         , eventScale                   :: Double
+                         , alphaQCD                     :: Double
+                         , alphaQED                     :: Double
+                         , signalProcessId              :: Int
+                         , barcode4SignalProcessVtx     :: Int
+                         , numVtx                       :: Int
+                         , barcodeBeam1                 :: Int
+                         , barcodeBeam2                 :: Int
+                         , randomStateList              :: (Int, [Int])     -- ^ (numEntries, randomStateIntergers)
+                         , weightList                   :: (Int, [Double])  -- ^ (numEntries, weights )
+                         , eventHeader                  :: EventHeader
+                         , vertices                     :: [GenVertex]
+                         } deriving (Show)
 
 data EventHeader = EventHeader { mWeightInfo   :: Maybe NamedWeight
                                , mUnitInfo     :: Maybe MomentumPositionUnit
-                               , mXsecInfo     :: Maybe GenXSec 
+                               , mXsecInfo     :: Maybe GenXSec
                                , mHeavyIonInfo :: Maybe HeavyIon
                                , mPdfInfo      :: Maybe PdfInfo
-                               }
-                 deriving (Show)
-            
-data NamedWeight = NamedWeight { numEntries :: Int
-                               , weightNames :: [ Text ] 
-                               }
-                 deriving (Show)
+                               } deriving (Show)
+
+data NamedWeight = NamedWeight { numEntries  :: Int
+                               , weightNames :: [ Text ]
+                               } deriving (Show)
 
 data MomentumPositionUnit = MomentumPositionUnit { momentumUnit :: MomentumUnit
-                                                 , lengthUnit :: LengthUnit 
-                                                 }
-                          deriving (Show)
+                                                 , lengthUnit   :: LengthUnit
+                                                 } deriving (Show)
 
-data GenXSec = GenXSec { xsecInPb :: Double 
-                       , errorInXsec :: Double }
-             deriving (Show)
+data GenXSec = GenXSec { xsecInPb    :: Double
+                       , errorInXsec :: Double
+                       } deriving (Show)
 
-data HeavyIon = HeavyIon { numHardScattering :: Int
-                         , numProjectileParticipants :: Int
-                         , numTargetParticipants :: Int
-                         , numNNCollisions :: Int
-                         , numSpectatorNeutrons :: Int
-                         , numSpectatorProtons :: Int
-                         , numNNwoundedCollisions :: Int
-                         , numNwoundedNCollisions :: Int
+data HeavyIon = HeavyIon { numHardScattering             :: Int
+                         , numProjectileParticipants     :: Int
+                         , numTargetParticipants         :: Int
+                         , numNNCollisions               :: Int
+                         , numSpectatorNeutrons          :: Int
+                         , numSpectatorProtons           :: Int
+                         , numNNwoundedCollisions        :: Int
+                         , numNwoundedNCollisions        :: Int
                          , numNwoundedNwoundedCollisions :: Int
-                         , impactParamCollision :: Double
-                         , azimuthalAngleEventPlane :: Double
-                         , eccentricityParticipatingNucleonsInTPlane :: Double
-                         , inelasticXsecNN :: Double }
-              deriving (Show)
+                         , impactParamCollision          :: Double
+                         , eventPlaneAngle               :: Double
+                         , eccentricity                  :: Double
+                         , inelasticXsecNN               :: Double
+                         } deriving (Show)
 
-data PdfInfo = PdfInfo { flavor1 :: Int
-                       , flavor2 :: Int
+data PdfInfo = PdfInfo { flavor1      :: Int
+                       , flavor2      :: Int
                        , beamMomFrac1 :: Double
                        , beamMomFrac2 :: Double
-                       , scaleQPDF :: Double
-                       , xfx1 :: Double
-                       , xfx2 :: Double
-                       , idLHAPDF1 :: Int
-                       , idLHAPDF2 :: Int } 
-             deriving (Show) 
+                       , scaleQPDF    :: Double
+                       , xfx1         :: Double
+                       , xfx2         :: Double
+                       , idLHAPDF1    :: Int
+                       , idLHAPDF2    :: Int
+                       } deriving (Show)
 
-data GenVertex = GenVertex { vbarcode :: Int
-                           , vid :: Int 
-                           , vx :: Double
-                           , vy :: Double
-                           , vz :: Double
-                           , vctau :: Double
+data GenVertex = GenVertex { vbarcode       :: Int
+                           , vid            :: Int
+                           , vx             :: Double
+                           , vy             :: Double
+                           , vz             :: Double
+                           , vctau          :: Double
                            , numOrphanInPtl :: Int
-                           , numOutPtl :: Int
-                           , vertexWeights :: (Int, [Double])  -- ^ ( numEntries, weights ) 
-                           , particles :: [GenParticle]
-                           } 
-               deriving (Show)
+                           , numOutPtl      :: Int
+                           , vertexWeights  :: (Int, [Double])  -- ^ ( numEntries, weights )
+                           , particles      :: [GenParticle]
+                           } deriving (Show)
 
-data GenParticle = GenParticle { pbarcode :: Int
-                               , pidPDG :: Int
-                               , px :: Double
-                               , py :: Double 
-                               , pz :: Double
-                               , pE :: Double
-                               , generatedMass :: Double
-                               , statusCode :: Int
-                               , polTheta :: Double 
-                               , polPhi :: Double
+data GenParticle = GenParticle { pbarcode              :: Int
+                               , pidPDG                :: Int
+                               , px                    :: Double
+                               , py                    :: Double
+                               , pz                    :: Double
+                               , pE                    :: Double
+                               , generatedMass         :: Double
+                               , statusCode            :: Int
+                               , polTheta              :: Double
+                               , polPhi                :: Double
                                , vbarcode4ThisIncoming :: Int
-                               , flows :: (Int, [(Int,Int)] ) -- ^ (numEntries, [ (code index, code) ] )
-                               }
-                 deriving (Show)
-
+                               , flows                 :: (Int, [(Int,Int)] ) -- ^ (numEntries, [ (code index, code) ] )
+                               } deriving (Show)


### PR DESCRIPTION
This adds `shell.nix` for building in the `nix-shell` and a flag for building tester. In the default configuration, it does not build `tester.hs`. In order to produce the executable, one can add the flag like

```
cabal configure --flags=devel
cabal build
```

This also cleans up some codes to remove warnings.
