### PR TITLE
Add helper functions for parsing with pipes

### DIFF
--- a/HepMC.cabal
+++ b/HepMC.cabal
@@ -18,7 +18,7 @@ flag devel
 executable tester
    main-is:          tester.hs
    hs-source-dirs:   exe
-   ghc-options:      -Wall -threaded -funbox-strict-fields -fno-warn-unused-do-bind
+   ghc-options:      -Wall -O2 -threaded -funbox-strict-fields -fno-warn-unused-do-bind
    ghc-prof-options: -caf-all -auto-all
    build-depends:    base == 4.*,
                      --
@@ -38,15 +38,18 @@ executable tester
 
 Library
   hs-source-dirs:    src
-  ghc-options:       -Wall -funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans
+  ghc-options:       -Wall -O2 -funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans
   ghc-prof-options:  -caf-all -auto-all
   Build-Depends:     base == 4.*,
                      --
                      attoparsec,
                      bytestring,
                      blaze-builder,
+                     pipes,
                      pipes-attoparsec,
-                     text
+                     pipes-text,
+                     text,
+                     transformers
   Exposed-Modules:
                      HEP.Parser.HepMC.Builder
                      HEP.Parser.HepMC.Parser


### PR DESCRIPTION
This adds simple functions (`hepmcEvent` and `parseEvent`) to help parsing with pipes. The test code has also been modified for illustration.
